### PR TITLE
feat: add public Helm repository via GitHub Pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
+  packages: write
 
 concurrency:
   group: "pages"
@@ -42,6 +43,32 @@ jobs:
       - name: Build chart dependencies
         run: |
           helm dependency build
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: charts
+          config: cr.yaml
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${{ github.repository_owner }}/helm-charts"
+          done
 
       - name: Create public directory
         run: mkdir -p public

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,4 @@
+sign: false
+# Enable automatic generation of release notes using GitHubs release notes generator.
+# see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+generate-release-notes: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,9 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+  - .
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
+helm-extra-args: --timeout 600s
+validate-maintainers: false


### PR DESCRIPTION
## Add Public Helm Repository

### What this does
Makes the Sequin Helm chart easy to install for everyone.

### Before this PR
- Users can't easily install the chart
- No public Helm repository exists
- Manual setup required

### After this PR
Users can install Sequin with 2 simple commands:
```bash
helm repo add sequin https://sequinstream.github.io/helm-chart-sequin
helm install my-sequin sequin/sequin
```

### Files changed
- **Added**: `.github/workflows/release.yml` - Auto-publishes the chart

### How it works
1. Push code to main branch
2. GitHub Actions builds and publishes chart automatically
3. Users can install from public repository

### What maintainers need to do
1. Enable GitHub Pages: Settings → Pages → Source: "GitHub Actions"
2. Merge this PR
3. That's it - everything else is automatic

### Benefits
- Easy installation for users
- No manual work for maintainers
- Follows standard Helm practices
- Works like other popular charts

### Test it works
After merge, users can run:
```bash
helm repo add sequin https://sequinstream.github.io/helm-chart-sequin
helm search repo sequin
helm install test sequin/sequin
```

**This only adds publishing - the chart itself doesn't change.**