### PR TITLE
Fix: Null bytes in secrets & support empty Redis password

### DIFF
--- a/templates/secret-external-redis.yaml
+++ b/templates/secret-external-redis.yaml
@@ -1,7 +1,7 @@
-{{- if and (not .Values.redis.enabled) (not .Values.externalRedis.existingSecret) .Values.externalRedis.password }}
+{{- if and (not .Values.redis.enabled) (not .Values.externalRedis.existingSecret) }}
 {{- $host := include "sequin.redis.host" . }}
 {{- $port := include "sequin.redis.port" . }}
-{{- $password := .Values.externalRedis.password . }}
+{{- $password := .Values.externalRedis.password }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  secret-key-base: {{ randBytes 64 | quote }}
-  vault-key: {{ randBytes 32 | quote }}
+  secret-key-base: {{ randBytes 64 | b64enc | quote }}
+  vault-key: {{ randBytes 32 | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Fix: Null bytes in secrets & support empty Redis password
Description:
- Base64-encode generated secret keys to prevent null byte errors in environment variables.
- Update Redis secret template to allow empty passwords, supporting Redis instances without authentication.