### PR TITLE
feat(service): support custom Service labels

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.labels .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -403,6 +403,9 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## @param service.labels Additional labels for the Sequin service
+  ##
+  labels: {}
 ## Sequin ingress parameters
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##


### PR DESCRIPTION
Adds a `service.labels` field in `values.yaml` so users can attach arbitrary labels to the Service. Template `templates/service.yaml` now merges those labels with existing `commonLabels` before rendering. No other behaviour is affected.