### PR TITLE
secrets.yaml should use secretKeyBase and vaultKey from values file if present 

### DIFF
--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  secret-key-base: {{ randBytes 64 | b64enc | quote }}
-  vault-key: {{ randBytes 32 | b64enc | quote }}
+  secret-key-base: {{ .Values.secretKeyBase | default (randBytes 64) | b64enc | quote }}
+  vault-key: {{ .Values.vaultKey | default (randBytes 32) | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
On `helm upgrade` on an instance that already has a source configured, generating random values causes decryption of the password to fail, breaking the Database connection.  Instead, we should enable using the stable values, if specified, so that the new pod comes up with the same keys.